### PR TITLE
In resourcereport show only resources with task on the report

### DIFF
--- a/lib/taskjuggler/PropertyList.rb
+++ b/lib/taskjuggler/PropertyList.rb
@@ -95,6 +95,21 @@ class TaskJuggler
       sort!
     end
 
+    # Remove Array of PropertyTreeNodes or a PropertyList of this. The 
+    # list will be sorted again.
+    def remove(list)
+      if $DEBUG
+        list.each do |node|
+          unless node.propertySet != @propertySet
+            raise "Fatal Error: All nodes must not belong to the same PropertySet."
+          end
+        end
+      end
+      # @items.delete(item)
+       @items -= list
+      sort!
+    end
+
     # If the first sorting level is 'tree' the breakdown structure of the
     # list is preserved. This is a somewhat special mode and this function
     # returns true if the mode is set.

--- a/lib/taskjuggler/reports/ResourceListRE.rb
+++ b/lib/taskjuggler/reports/ResourceListRE.rb
@@ -53,13 +53,22 @@ class TaskJuggler
       taskList.sort!
 
       assignedTaskList = []
+      resourceToRemove = []
       resourceList.each do |resource|
-        assignedTaskList += filterTaskList(taskList, resource,
-                                           @report.get('hideTask'),
-                                           @report.get('rollupTask'),
-                                           @report.get('openNodes'))
-        assignedTaskList.uniq!
+        currentResourceAssignedTaskList = filterTaskList(taskList, resource,
+                                                          @report.get('hideTask'),
+                                                          @report.get('rollupTask'),
+                                                          @report.get('openNodes'))
+        if currentResourceAssignedTaskList.any?
+          assignedTaskList += currentResourceAssignedTaskList
+          assignedTaskList.uniq!
+        else
+          resourceToRemove << resource
+        end
       end
+
+      resourceList.remove(resourceToRemove)
+
 
       adjustReportPeriod(assignedTaskList, @report.get('scenarios'),
                          @report.get('columns'))


### PR DESCRIPTION
I think that only resources with real tasks on resourcereport should be displayed.

I did not find any solution in documentation, I searched in source code, I did not either find so I made the following patch.

Maybe it could be a report option or a resource filter option ?

JJay
