### PR TITLE
Remove weekStartsMonday and weekStartsSunday and replace with weekStartsOn

### DIFF
--- a/lib/taskjuggler/Limits.rb
+++ b/lib/taskjuggler/Limits.rb
@@ -197,14 +197,14 @@ class TaskJuggler
         upper = false
       when 'weeklymax'
         iv.start = iv.startDate.beginOfWeek(
-          @project['weekStartsMonday'])
-        iv.end = iv.endDate.beginOfWeek(@project['weekStartsMonday'])
+          @project['weekStartsOn'])
+        iv.end = iv.endDate.beginOfWeek(@project['weekStartsOn'])
         period = 60 * 60 * 24 * 7
         upper = true
       when 'weeklymin'
         iv.start = iv.startDate.beginOfWeek(
-          @project['weekStartsMonday'])
-        iv.end = iv.endDate.beginOfWeek(@project['weekStartsMonday'])
+          @project['weekStartsOn'])
+        iv.end = iv.endDate.beginOfWeek(@project['weekStartsOn'])
         period = 60 * 60 * 24 * 7
         upper = false
       when 'monthlymax'

--- a/lib/taskjuggler/Project.rb
+++ b/lib/taskjuggler/Project.rb
@@ -98,7 +98,7 @@ class TaskJuggler
         'timezone' => TjTime.timeZone,
         'trackingScenarioIdx' => nil,
         'version' => version || "1.0",
-        'weekStartsMonday' => true,
+        'weekStartsOn' => 0,
         'workinghours' => nil,
         'yearlyworkingdays' => 260.714
       }
@@ -450,8 +450,8 @@ class TaskJuggler
               true,  false,   false, nil ],
         [ 'tree',      'Tree Index',   StringAttribute,
               false, false,   false, "" ],
-        [ 'weekStartsMonday', 'Week Starts Monday', BooleanAttribute,
-              true,  true,    false, false ],
+        [ 'weekStartsOn', 'Week Starts On', FixnumAttribute,
+              true,  true,    false, 0 ],
         [ 'width',     'Width',        FixnumAttribute,
               true,  false,   false, 640 ]
       ]

--- a/lib/taskjuggler/Tj3Config.rb
+++ b/lib/taskjuggler/Tj3Config.rb
@@ -16,10 +16,10 @@ require 'taskjuggler/AppConfig'
 
 AppConfig.version = '3.3.0'
 AppConfig.packageName = 'taskjuggler'
-AppConfig.softwareName = 'TaskJuggler'
+AppConfig.softwareName = 'TaskJuggler-AJL'
 AppConfig.packageInfo = 'A Project Management Software'
 AppConfig.copyright = [ (2006..2012).to_a ]
-AppConfig.authors = [ 'Chris Schlaeger <chris@linux.com>' ]
+AppConfig.authors = [ 'Chris Schlaeger <chris@linux.com>', 'AJ Lewis <aj.lewis@quantum.com>' ]
 AppConfig.contact = 'http://www.taskjuggler.org'
 AppConfig.license = <<'EOT'
 This program is free software; you can redistribute it and/or modify it under

--- a/lib/taskjuggler/TjTime.rb
+++ b/lib/taskjuggler/TjTime.rb
@@ -205,19 +205,23 @@ class TaskJuggler
       TjTime.new([ year, month, day, hour, min, sec, 0 ])
     end
 
-    # Normalize time to the beginning of the current week. _startMonday_
-    # determines whether the week should start on Monday or Sunday.
-    def beginOfWeek(startMonday)
+    # Normalize time to the beginning of the current week. _startOn_
+    # determines what day the week should start on
+    def beginOfWeek(startOn)
       t = localtime.to_a
       # Set time to noon, 12:00:00
       t[0, 3] = [ 0, 0, 12 ]
       weekday = t[6]
       t.slice!(6, 4)
       t.reverse!
+      newweekday = weekday - startOn
+      if (newweekday < 0)
+        newweekday += 7
+      end
       # Substract the number of days determined by the weekday t[6] and set time
       # to midnight of that day.
       (TjTime.new(Time.local(*t)) -
-       (weekday - (startMonday ? 1 : 0)) * 60 * 60 * 24).midnight
+       (newweekday) * 60 * 60 * 24).midnight
     end
 
     # Normalize time to the beginning of the current month.

--- a/lib/taskjuggler/TjpSyntaxRules.rb
+++ b/lib/taskjuggler/TjpSyntaxRules.rb
@@ -3303,19 +3303,19 @@ EOT
        )
     example('TimeSheet1', '2')
 
-    pattern(%w( _weekstartsmonday ), lambda {
-      @project['weekStartsMonday'] = true
+    pattern(%w( _weekstartson !number), lambda {
+      @project['weekStartsOn'] = @val[1]
     })
-    doc('weekstartsmonday',
-        'Specify that you want to base all week calculation on weeks ' +
-        'starting on Monday. This is common in many European countries.')
+    doc('weekstartson',
+        'Specify the day of the week you want to base all week calculation on ' +
+        'Sunday=0, Monday=1, etc.')
 
-    pattern(%w( _weekstartssunday ), lambda {
-      @project['weekStartsMonday'] = false
-    })
-    doc('weekstartssunday',
-        'Specify that you want to base all week calculation on weeks ' +
-        'starting on Sunday. This is common in the United States of America.')
+#    pattern(%w( _weekstartssunday ), lambda {
+#      @project['weekStartsMonday'] = false
+#    })
+#    doc('weekstartssunday',
+#        'Specify that you want to base all week calculation on weeks ' +
+#        'starting on Sunday. This is common in the United States of America.')
 
     pattern(%w( !workinghoursProject ))
     pattern(%w( _yearlyworkingdays !number ), lambda {

--- a/lib/taskjuggler/reports/GanttChart.rb
+++ b/lib/taskjuggler/reports/GanttChart.rb
@@ -34,16 +34,16 @@ class TaskJuggler
 
     include HTMLGraphics
 
-    attr_reader :start, :end, :now, :weekStartsMonday, :header, :width,
+    attr_reader :start, :end, :now, :weekStartsOn, :header, :width,
                 :scale, :scales, :table
     attr_writer :viewWidth
 
     # Create the GanttChart object, but don't do much right now. We still need
     # more information about the chart before we can actually generate it. _now_
-    # is the date that should be used as current date. _weekStartsMonday_ is
-    # true if the weeks should start on Mondays instead of Sundays. _table_ is a
+    # is the date that should be used as current date. _weekStartsOn is
+    # a number representing the first day of the week. _table_ is a
     # reference to the TableReport that the chart is part of.
-    def initialize(now, weekStartsMonday, columnDef, table = nil)
+    def initialize(now, weekStartsOn, columnDef, table = nil)
       # The start and end dates of the reported interval.
       @start = nil
       @end = nil
@@ -83,7 +83,7 @@ class TaskJuggler
       # view will be adapted to the width of the chart.
       @viewWidth = nil
       # True of the week starts on a Monday.
-      @weekStartsMonday = weekStartsMonday
+      @weekStartsOn = weekStartsOn
 
       # Reference to the GanttHeader object that models the chart header.
       @header = nil

--- a/lib/taskjuggler/reports/GanttHeader.rb
+++ b/lib/taskjuggler/reports/GanttHeader.rb
@@ -110,7 +110,7 @@ class TaskJuggler
       # The beginOfWeek function needs a parameter, so we have to handle it as a
       # special case.
       if beginOfFunc == :beginOfWeek
-        t = @chart.start.send(beginOfFunc, @chart.weekStartsMonday)
+        t = @chart.start.send(beginOfFunc, @chart.weekStartsOn)
       else
         t = @chart.start.send(beginOfFunc)
       end

--- a/lib/taskjuggler/reports/TableReport.rb
+++ b/lib/taskjuggler/reports/TableReport.rb
@@ -339,7 +339,7 @@ class TaskJuggler
         # set so that the lines of the Gantt chart line up with the lines of the
         # table.
         gantt = GanttChart.new(a('now'),
-                               a('weekStartsMonday'), columnDef, self)
+                               a('weekStartsOn'), columnDef, self)
 
         gantt.generateByScale(rStart, rEnd, columnDef.scale)
         # The header consists of 2 lines separated by a 1 pixel boundary.
@@ -361,7 +361,7 @@ class TaskJuggler
                           '%b %Y', '%d')
       when 'weekly'
         genCalChartHeader(columnDef,
-                          rStart.beginOfWeek(a('weekStartsMonday')), rEnd,
+                          rStart.beginOfWeek(a('weekStartsOn')), rEnd,
                           :sameTimeNextWeek, '%b %Y', '%d')
       when 'monthly'
         genCalChartHeader(columnDef, rStart.beginOfMonth, rEnd,
@@ -662,7 +662,7 @@ class TaskJuggler
         start = query.start.midnight
         sameTimeNextFunc = :sameTimeNextDay
       when 'weekly'
-        start = query.start.beginOfWeek(a('weekStartsMonday'))
+        start = query.start.beginOfWeek(a('weekStartsOn'))
         sameTimeNextFunc = :sameTimeNextWeek
       when 'monthly'
         start = query.start.beginOfMonth


### PR DESCRIPTION
This change allows the work week to start on any day - this is 0-based starting with Sunday.

Not sure if this would be useful for anyone else, but I need to get my status in to my manager on Thursday so that they can get their status consolidated and up the management chain on time.  This way I can view the project based on a Thursday week start. 
