### PR TITLE
Fix: Resolve symlinks when constructing lib path.

### DIFF
--- a/bin/tj3
+++ b/bin/tj3
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$:.unshift File.join(File.dirname(File.realpath(__FILE__)), '..', 'lib')
 require File.basename(__FILE__)

--- a/bin/tj3client
+++ b/bin/tj3client
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$:.unshift File.join(File.dirname(File.realpath(__FILE__)), '..', 'lib')
 require File.basename(__FILE__)

--- a/bin/tj3d
+++ b/bin/tj3d
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$:.unshift File.join(File.dirname(File.realpath(__FILE__)), '..', 'lib')
 require File.basename(__FILE__)

--- a/bin/tj3man
+++ b/bin/tj3man
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$:.unshift File.join(File.dirname(File.realpath(__FILE__)), '..', 'lib')
 require File.basename(__FILE__)

--- a/bin/tj3ss_receiver
+++ b/bin/tj3ss_receiver
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$:.unshift File.join(File.dirname(File.realpath(__FILE__)), '..', 'lib')
 require File.basename(__FILE__)

--- a/bin/tj3ss_sender
+++ b/bin/tj3ss_sender
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$:.unshift File.join(File.dirname(File.realpath(__FILE__)), '..', 'lib')
 require File.basename(__FILE__)

--- a/bin/tj3ts_receiver
+++ b/bin/tj3ts_receiver
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$:.unshift File.join(File.dirname(File.realpath(__FILE__)), '..', 'lib')
 require File.basename(__FILE__)

--- a/bin/tj3ts_sender
+++ b/bin/tj3ts_sender
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$:.unshift File.join(File.dirname(File.realpath(__FILE__)), '..', 'lib')
 require File.basename(__FILE__)

--- a/bin/tj3ts_summary
+++ b/bin/tj3ts_summary
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$:.unshift File.join(File.dirname(File.realpath(__FILE__)), '..', 'lib')
 require File.basename(__FILE__)

--- a/bin/tj3webd
+++ b/bin/tj3webd
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-$:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
+$:.unshift File.join(File.dirname(File.realpath(__FILE__)), '..', 'lib')
 require File.basename(__FILE__)


### PR DESCRIPTION
This fix allows TaskJuggler to correctly find its libraries when run through a symlink. Without this patch, the current code will construct a path based on the symlink's location and thus yield an error in most cases.
