### PR TITLE
fixed regexp

### DIFF
--- a/lib/taskjuggler/reports/Report.rb
+++ b/lib/taskjuggler/reports/Report.rb
@@ -466,7 +466,7 @@ EOT
 
     def absoluteFileName?(name)
       if windowsOS?
-        name[0] =~ /a-zA-Z/ && name[1] == ?:
+        name[0] =~ /[a-zA-Z]/ && name[1] == ?:
       else
         name[0] == ?/
       end


### PR DESCRIPTION
The regular expression that is used to check for a leading character in the filename misses the surrounding brackets. Therefore "a-zA-Z" is treated literally and not like a range. Hence absoluteFileName? always returns nil on Windows.
