### PR TITLE
add --logfile option to tj3d and tj3webd

### DIFF
--- a/lib/taskjuggler/apps/Tj3Daemon.rb
+++ b/lib/taskjuggler/apps/Tj3Daemon.rb
@@ -57,7 +57,11 @@ EOT
                         'requests (Default: 8474).')) do |arg|
           @port = arg
         end
-        @opts.on('--urifile', String,
+        @opts.on('--logfile <FILE NAME>', String,
+                          format('Log daemon messages to the specified file.')) do |arg|
+              @mhi.logFile = arg
+              end
+        @opts.on('--urifile <FILE NAME>', String,
                  format('If the port is 0, use this file to store the URI ' +
                         'of the server.')) do |arg|
           @uriFile = arg

--- a/lib/taskjuggler/apps/Tj3WebD.rb
+++ b/lib/taskjuggler/apps/Tj3WebD.rb
@@ -60,7 +60,11 @@ EOT
                         'specified file.')) do |arg|
           @pidFile = arg
         end
-        @opts.on('--urifile', String,
+        @opts.on('--logfile <FILE NAME>', String,
+                 format('Log daemon messages to the specified file.')) do |arg|
+          @mhi.logFile = arg
+        end
+        @opts.on('--urifile <FILE NAME>', String,
                  format('If the port is 0, use this file to read the URI ' +
                         'of the TaskJuggler daemon.')) do |arg|
           @uriFile = arg


### PR DESCRIPTION
When used, log messages are saved to specified file instead of ./tj3d.log and ./tj3webd.log.