### PR TITLE
Fix duplicate timeFormat entry

### DIFF
--- a/lib/taskjuggler/TaskJuggler.rb
+++ b/lib/taskjuggler/TaskJuggler.rb
@@ -353,7 +353,6 @@ class TaskJuggler
                      'timeFormat' => '%Y-%m-%d',
                      'start' => ss[1],
                      'end' => ss[2],
-                     'timeFormat' => '%Y-%m-%d',
                      'selfContained' => true }
       query = Query.new(queryAttrs)
       puts ss[0].query_dashboard(query).richText.inputText


### PR DESCRIPTION
Solves this ruby warning seen on Fedora 22:
/usr/local/share/gems/gems/taskjuggler-3.5.0/lib/taskjuggler/TaskJuggler.rb:353: warning: duplicated key at line 356 ignored: "timeFormat"