### PR TITLE
Fix: syntax of xml comments to not have -- in the body

### DIFF
--- a/lib/taskjuggler/XMLElement.rb
+++ b/lib/taskjuggler/XMLElement.rb
@@ -202,9 +202,17 @@ class TaskJuggler
       super(nil, {})
       @text = text
     end
-
+    ## It is crucial to canonicalize xml comment text because xml
+    ## comment syntax forbids having a -- in the comment body.  I
+    ## picked emacs's "M-x comment-region" approach of putting a
+    ## backslash between the two.
+    def canonicalize_comment(text)
+      new_text = text.gsub("--", "-\\-")
+      new_text
+    end
     def to_s(indent)
-      '<!-- ' + @text + " -->\n#{' ' * indent}"
+      @comment_text = canonicalize_comment(@text)
+      '<!-- ' + @comment_text + " -->\n#{' ' * indent}"
     end
 
   end


### PR DESCRIPTION
There was a problem with the xml saving of a project: it would have a
comment that looked like this:

<!-- Generated by TaskJuggler v3.6.0 on 2016-04-18-14:04:15-\-0600 [...]

xml does not allow comments to have a -- in the body, and xmllint was
failing on these xml files.  The XMLComment class now canonicalizes
the comment string to have -\- instead of --, which is the same
approach emacs uses in "M-x comment-region".