### PR TITLE
Fix: Clean the source tree using rake

### DIFF
--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -1,5 +1,7 @@
 require 'time'
 
+CLOBBER.include "CHANGELOG"
+
 desc 'Generate the CHANGELOG file'
 task :changelog do
 

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -3,6 +3,8 @@ require 'find'
 require 'rubygems'
 require 'rubygems/package'
 
+CLOBBER.include "pkg/"
+
 # Unfortunately Rake::GemPackageTest cannot deal with files that are generated
 # by Rake targets. So we have to write our own packaging task.
 desc 'Build the gem package'

--- a/tasks/kate.rake
+++ b/tasks/kate.rake
@@ -2,6 +2,8 @@
 
 require 'taskjuggler/KateSyntax'
 
+CLOBBER.include "data/kate-tjp.xml"
+
 desc 'Generate kate-tjp.xml Kate syntax file'
 task :kate do
   TaskJuggler::KateSyntax.new.generate('data/kate-tjp.xml')

--- a/tasks/manual.rake
+++ b/tasks/manual.rake
@@ -2,6 +2,8 @@
 
 require 'taskjuggler/apps/Tj3Man'
 
+CLOBBER.include "manual/html/"
+
 desc 'Generate User Manual'
 task :manual do
   htmldir = 'manual/html'

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -2,6 +2,11 @@ $:.unshift File.join(File.dirname(__FILE__), '..', 'test')
 
 require 'rake/testtask'
 
+CLEAN.include "test/TestSuite/Export-Reports/refs/Leave.tjp"
+CLEAN.include "test/TestSuite/Export-Reports/refs/ListAttributes.tjp"
+CLEAN.include "test/TestSuite/Export-Reports/refs/Macro-4.tjp"
+CLEAN.include "test/TestSuite/Export-Reports/refs/TraceReport.tjp"
+
 # TEST TASK
 desc 'Run all unit tests in the test directory'
 Rake::TestTask.new(:unittest) do |t|

--- a/tasks/vim.rake
+++ b/tasks/vim.rake
@@ -2,6 +2,8 @@
 
 require 'taskjuggler/VimSyntax'
 
+CLOBBER.include "data/tjp.vim"
+
 desc 'Generate vim.tjp Vim syntax file'
 task :vim do
   TaskJuggler::VimSyntax.new.generate('data/tjp.vim')


### PR DESCRIPTION
Modify several rake tasks so that running 'rake clean' will remove any intermediate files
and running 'rake clobber' will remove any final products.

Signed-off-by: Christopher Hoskin christopher.hoskin@gmail.com
