### PR TITLE
Provide man pages for TaskJuggler

### DIFF
--- a/h2m/tj3.h2m
+++ b/h2m/tj3.h2m
@@ -1,0 +1,25 @@
+[NAME]
+tj3 \- schedules tj3 projects and generates reports
+
+[ENVIRONMENT]
+
+.TP
+\fBTASKJUGGLER_DATA_PATH\fR
+Override the path to the TaskJuggler data folder.
+The data folder contains the css, icons and scripts
+for TaskJuggler reports.
+
+.TP
+\fBTZ\fR
+The POSIX Time Zone environment variable.
+
+Any environment variable may be used in a TaskJuggler file using the expression $(VAR_NAME).
+
+[EXAMPLES]
+
+tj3 tutorial.tjp
+
+[SEE ALSO]
+tj3client(1), tj3d(1), tj3man(1), tj3ss_receiver(1), tj3ss_sender(1), tj3ts_receiver(1), tj3ts_sender(1), tj3ts_summary(1), tj3webd(1)
+
+The full TaskJuggler manual is available online at http://www.taskjuggler.org/tj3/manual/, or via the tj3man command.

--- a/h2m/tj3client.h2m
+++ b/h2m/tj3client.h2m
@@ -1,0 +1,43 @@
+[NAME]
+tj3client \- send commands and data to the TaskJuggler daemon
+
+[ENVIRONMENT]
+
+.TP
+\fBHOME\fR
+The user's home folder. Used to search for configuration file if not specified.
+
+[FILES]
+
+.TP
+\fB.taskjugglerrc\fR or \fBtaskjuggler.rc\fR
+tj3d searches for a config file named .taskjugglerrc or taskjuggler.rc in the current path, the user's home path as specified by the HOME environment variable or /etc/. At a minimum the file must contain:
+
+_global:
+  authKey: ********
+
+(the user should specify their own auth key and set file permissions accordingly). An alternative config file location may be specified using the -c, --config FILE option.
+
+[EXAMPLES]
+.TP
+Load a project:
+tj3client add yourproject.tjp
+.PP
+.TP
+List available reports for a project:
+tj3client list-reports <project_id>
+.PP
+.TP
+Generate a report:
+tj3client report <project_id> <report_id>
+.PP
+.TP
+Terminate a running instance of the server:
+tj3client terminate
+
+
+
+[SEE ALSO]
+tj3d(1)
+
+The full TaskJuggler manual is available online at http://www.taskjuggler.org/tj3/manual/, or via the tj3man command.

--- a/h2m/tj3d.h2m
+++ b/h2m/tj3d.h2m
@@ -1,0 +1,33 @@
+[NAME]
+tjd3 \- the TaskJuggler daemon
+
+[ENVIRONMENT]
+
+.TP
+\fBHOME\fR
+The user's home folder. Used to search for configuration file if not specified.
+
+[FILES]
+
+.TP
+\fB.taskjugglerrc\fR or \fBtaskjuggler.rc\fR
+tj3d searches for a config file named .taskjugglerrc or taskjuggler.rc in the current path, the user's home path as specified by the HOME environment variable or /etc/. At a minimum the file must contain:
+
+_global:
+  authKey: ********
+
+(the user should specify their own auth key and set file permissions accordingly). An alternative config file location may be specified using the -c, --config FILE option.
+
+.TP
+\fBtj3d.log\fR
+
+The tj3d log file, created in the working directory. Location can be overridden using the --logfile FILE option.
+
+[SECURITY]
+The author advises: "the daemon has not received any kind of security review ... only use the daemon in a trusted environment with only trusted users!"
+
+
+[SEE ALSO]
+tj3client(1)
+
+The full TaskJuggler manual is available online at http://www.taskjuggler.org/tj3/manual/, or via the tj3man command.

--- a/h2m/tj3man.h2m
+++ b/h2m/tj3man.h2m
@@ -1,0 +1,22 @@
+[NAME]
+tj3man \- get documentation for TaskJuggler keywords or generate user manual
+
+[ENVIRONMENT]
+
+.TP
+\fBBROWSER\fR
+The web browser used to display the user manual as HTML.
+
+[EXAMPLES]
+
+tj3man shift
+.br
+tj3man --html shift.timesheet
+.br
+tj3man --html
+
+[SEE ALSO]
+
+tj3(1)
+
+The TaskJuggler manual is also available online at http://www.taskjuggler.org/tj3/manual/.

--- a/h2m/tj3ss_receiver.h2m
+++ b/h2m/tj3ss_receiver.h2m
@@ -1,0 +1,41 @@
+[NAME]
+tj3ss_receiver \- receive filled-out status sheets via email
+
+[ENVIRONMENT]
+
+.TP
+\fBHOME\fR
+The user's home folder. Used to search for configuration file if not specified.
+
+
+[FILES]
+.TP
+\fB.taskjugglerrc\fR or \fBtaskjuggler.rc\fR
+tj3d searches for a config file named .taskjugglerrc or taskjuggler.rc in the current path, the user's home path as specified by the HOME environment variable or /etc/. At a minimum the file must configure an e-mail delivery method and sender e-mail e.g.:
+
+_global:
+   emailDeliveryMethod: smtp
+   smtpServer: smtp.your_company.com
+.br
+_statussheets:
+   senderEmail: 'TaskJuggler <statussheets@taskjuggler.amd.com>'
+
+An alternative config file location may be specified using the -c, --config FILE option.
+
+.TP
+\fBstatussheets.log\fR
+The statussheets log file, created in the working directory.
+
+.TP
+\fBStatusSheets/FailedMails/\fR
+Directory created in the working directory to store the failed emails.
+
+.TP
+\fBStatusSheets/FailedSheets/\fR
+Directory created in the working directory to store the failed status sheets.
+
+
+[SEE ALSO]
+tj3ss_sender(1)
+
+The full TaskJuggler manual is available online at http://www.taskjuggler.org/tj3/manual/, or via the tj3man command.

--- a/h2m/tj3ss_sender.h2m
+++ b/h2m/tj3ss_sender.h2m
@@ -1,0 +1,38 @@
+[NAME]
+tj3ss_sender \- send out status sheets templates via email
+
+[ENVIRONMENT]
+
+.TP
+\fBHOME\fR
+The user's home folder. Used to search for configuration file if not specified.
+
+
+[FILES]
+
+\fB.taskjugglerrc\fR or \fBtaskjuggler.rc\fR
+tj3d searches for a config file named .taskjugglerrc or taskjuggler.rc in the current path, the user's home path as specified by the HOME environment variable or /etc/. At a minimum the file must configure an authentication key, an e-mail delivery method and sender e-mail e.g.:
+
+_global:
+   authKey: ********
+   smtpServer: smtp.your_company.com
+.br
+_statussheets:
+   senderEmail: 'TaskJuggler <statussheets@taskjuggler.amd.com>'
+
+(the user should specify their own auth key and set file permissions accordingly). An alternative config file location may be specified using the -c, --config FILE option.
+
+.TP
+\fBstatussheets.log\fR
+The statussheets log file, created in the working directory.
+
+.TP
+\fBStatusSheetTemplates\fR
+Base directory of the sheet templates, created in the working directory.
+
+
+[SEE ALSO]
+
+tj3ss_receiver(1), tj3d(1)
+
+The full TaskJuggler manual is available online at http://www.taskjuggler.org/tj3/manual/, or via the tj3man command.

--- a/h2m/tj3ts_receiver.h2m
+++ b/h2m/tj3ts_receiver.h2m
@@ -1,0 +1,41 @@
+[NAME]
+tj3ts_receiver \- receive filled-out time sheets via email
+
+[ENVIRONMENT]
+
+.TP
+\fBHOME\fR
+The user's home folder. Used to search for configuration file if not specified.
+
+
+[FILES]
+.TP
+\fB.taskjugglerrc\fR or \fBtaskjuggler.rc\fR
+tj3d searches for a config file named .taskjugglerrc or taskjuggler.rc in the current path, the user's home path as specified by the HOME environment variable or /etc/. At a minimum the file must configure an authentication key, an e-mail delivery method and sender e-mail e.g.:
+
+_global:
+   authKey: ********
+   smtpServer: smtp.your_company.com
+_timesheets:
+   senderEmail: 'TaskJuggler <timesheets@taskjuggler.amd.com>'
+
+(the user should specify their own auth key and set file permissions accordingly). An alternative config file location may be specified using the -c, --config FILE option.
+
+.TP
+\fBtimesheets.log\fR
+The statussheets log file, created in the working directory.
+
+.TP
+\fBTimeSheets/FailedMails/\fR
+Directory created in the working directory to store the failed emails.
+
+.TP
+\fBTimeSheets/FailedSheets/\fR
+Directory created in the working directory to store the failed status sheets.
+
+
+[SEE ALSO]
+
+tj3ts_sender(1)
+
+The full TaskJuggler manual is available online at http://www.taskjuggler.org/tj3/manual/, or via the tj3man command.

--- a/h2m/tj3ts_sender.h2m
+++ b/h2m/tj3ts_sender.h2m
@@ -1,0 +1,37 @@
+[NAME]
+tj3ts_sender \- send out time sheets templates via email
+
+[ENVIRONMENT]
+
+.TP
+\fBHOME\fR
+The user's home folder. Used to search for configuration file if not specified.
+
+[FILES]
+
+\fB.taskjugglerrc\fR or \fBtaskjuggler.rc\fR
+tj3d searches for a config file named .taskjugglerrc or taskjuggler.rc in the current path, the user's home path as specified by the HOME environment variable or /etc/. At a minimum the file must configure an authentication key, an e-mail delivery method and sender e-mail e.g.:
+
+_global:
+   authKey: ********
+   smtpServer: smtp.your_company.com
+   projectId: acso
+.br
+_timesheets:
+   senderEmail: 'TaskJuggler <statussheets@taskjuggler.amd.com>'
+
+(the user should specify their own auth key and set file permissions accordingly). An alternative config file location may be specified using the -c, --config FILE option.
+
+.TP
+\fBtimesheets.log\fR
+The timesheets log file, created in the working directory.
+
+.TP
+\fBTimeSheetTemplates\fR
+Base directory of the sheet templates, created in the working directory.
+
+
+[SEE ALSO]
+tj3ts_receiver(1)
+
+The full TaskJuggler manual is available online at http://www.taskjuggler.org/tj3/manual/, or via the tj3man command.

--- a/h2m/tj3ts_summary.h2m
+++ b/h2m/tj3ts_summary.h2m
@@ -1,0 +1,42 @@
+[NAME]
+tj3ts_summary \- send out individual copies and a summary of accepted time sheets
+
+[ENVIRONMENT]
+
+.TP
+\fBHOME\fR
+The user's home folder. Used to search for configuration file if not specified.
+
+
+[FILES]
+
+\fB.taskjugglerrc\fR or \fBtaskjuggler.rc\fR
+tj3d searches for a config file named .taskjugglerrc or taskjuggler.rc in the current path, the user's home path as specified by the HOME environment variable or /etc/. At a minimum the file must configure an authentication key, an e-mail delivery method, project id, sender e-mail and receipients e.g.:
+
+_global:
+   authKey: ********
+   smtpServer: smtp.your_company.com
+   projectId: acso
+.br
+_timesheets:
+   senderEmail: 'TaskJuggler <statussheets@taskjuggler.amd.com>'
+  _summary:
+    sheetRecipients:
+      - team@your_company.com
+
+(the user should specify their own auth key and set file permissions accordingly). An alternative config file location may be specified using the -c, --config FILE option.
+
+
+.TP
+\fBtimesheets.log\fR
+The timesheets log file, created in the working directory.
+
+.TP
+\fBTimeSheetTemplates\fR
+Base directory of the sheet templates, created in the working directory.
+
+
+[SEE ALSO]
+tj3ts_receiver(1)  tj3ts_sender(1)
+
+The full TaskJuggler manual is available online at http://www.taskjuggler.org/tj3/manual/, or via the tj3man command.

--- a/h2m/tj3webd.h2m
+++ b/h2m/tj3webd.h2m
@@ -1,0 +1,24 @@
+[NAME]
+tj3webd \- TaskJuggler reports web server
+
+[ENVIRONMENT]
+
+.TP
+\fBHOME\fR
+The user's home folder. Used to search for configuration file if not specified.
+
+[FILES]
+
+.TP
+\fB.taskjugglerrc\fR or \fBtaskjuggler.rc\fR
+tj3d searches for a config file named .taskjugglerrc or taskjuggler.rc in the current path, the user's home path as specified by the HOME environment variable or /etc/. At a minimum the file must contain:
+
+_global:
+  authKey: ********
+
+(the user should specify their own auth key and set file permissions accordingly). An alternative config file location may be specified using the -c, --config FILE option.
+
+[SEE ALSO]
+tj3d(1)
+
+The full TaskJuggler manual is available online at http://www.taskjuggler.org/tj3/manual/, or via the tj3man command.

--- a/lib/taskjuggler/Tj3AppBase.rb
+++ b/lib/taskjuggler/Tj3AppBase.rb
@@ -51,16 +51,15 @@ class TaskJuggler
       @opts.summary_width = @optsSummaryWidth
       @opts.summary_indent = ' ' * @optsSummaryIndent
 
-      @opts.banner = "#{AppConfig.softwareName} v#{AppConfig.version} - " +
-                     "#{AppConfig.packageInfo}\n\n" +
-                     "Copyright (c) #{AppConfig.copyright.join(', ')}\n" +
+      @opts.banner = "Copyright (c) #{AppConfig.copyright.join(', ')}\n" +
                      "              by #{AppConfig.authors.join(', ')}\n\n" +
                      "#{AppConfig.license}\n" +
                      "For more info about #{AppConfig.softwareName} see " +
                      "#{AppConfig.contact}\n\n" +
                      "Usage: #{AppConfig.appName} [options] " +
                      "#{@mandatoryArgs}\n\n"
-      @opts.separator ""
+
+      @opts.separator "\nOptions:"
       @opts.on('-c', '--config <FILE>', String,
                format('Use the specified YAML configuration file')) do |arg|
          @configFile = arg
@@ -91,8 +90,23 @@ EOT
         quit
       end
       @opts.on_tail('--version', format('Show version info')) do
-        puts "#{AppConfig.softwareName} v#{AppConfig.version} - " +
-          "#{AppConfig.packageInfo}"
+# Display the software name and version in GNU format
+# as expected by help2man
+# https://www.gnu.org/prep/standards/standards.html#g_t_002d_002dversion
+        puts "#{AppConfig.appName} (#{AppConfig.softwareName}) #{AppConfig.version}\n"
+# To also display the copyright and license statements in GNU format
+# uncomment the following and remove the equivalent statements from
+# --help
+# +
+#<<'EOT'
+#Copyright (C) 2016 Chris Schlaeger <cs@taskjuggler.org>
+#License GPLv2: GNU GPL version 2 <http://gnu.org/licenses/gpl.html>
+#This is free software; you can redistribute it and/or modify it under
+#the terms of version 2 of the GNU General Public License as published by the
+#Free Software Foundation.
+#
+#For more info about TaskJuggler see http://www.taskjuggler.org
+#EOT
         quit
       end
 

--- a/lib/taskjuggler/apps/Tj3.rb
+++ b/lib/taskjuggler/apps/Tj3.rb
@@ -68,10 +68,12 @@ class TaskJuggler
 
     def processArguments(argv)
       super do
-        @opts.banner += <<'EOT'
+        @opts.banner.prepend(<<'EOT'
 This is the main application. It reads in your project files, schedules the
 project and generates the reports.
+
 EOT
+	)
         @opts.on('--debuglevel N', Integer,
                  format("Verbosity of debug output")) do |arg|
           TaskJuggler::Log.level = arg

--- a/lib/taskjuggler/apps/Tj3Client.rb
+++ b/lib/taskjuggler/apps/Tj3Client.rb
@@ -100,7 +100,7 @@ class TaskJuggler
 
     def processArguments(argv)
       super do
-        @opts.banner += <<'EOT'
+        prebanner = <<'EOT'
 The TaskJuggler client is used to send commands and data to the TaskJuggler
 daemon. The communication is done via TCP/IP.
 
@@ -125,9 +125,10 @@ EOT
             end
           end
           args = args.join(' ')
-          @opts.banner += "     #{cmd[:label] + ' ' + args + tail}" +
+          prebanner += "     #{cmd[:label] + ' ' + args + tail}" +
                           "\n\n#{' ' * 10 + format(cmd[:descr], 10)}\n"
         end
+	@opts.banner.prepend(prebanner)
         @opts.on('-p', '--port <NUMBER>', Integer,
                  format('Use the specified TCP/IP port')) do |arg|
            @port = arg

--- a/lib/taskjuggler/apps/Tj3Daemon.rb
+++ b/lib/taskjuggler/apps/Tj3Daemon.rb
@@ -42,11 +42,13 @@ class TaskJuggler
 
     def processArguments(argv)
       super do
-        @opts.banner += <<'EOT'
+        @opts.banner.prepend(<<'EOT'
 The TaskJuggler daemon can be used to quickly generate reports for a number
 of scheduled projects that are resident in memory. Once the daemon has been
 started tj3client can be used to control it.
+
 EOT
+	)
         @opts.on('-d', '--dont-daemonize',
                  format("Don't put program into daemon mode. Keep it " +
                         'connected to the terminal and show debug output.')) do

--- a/lib/taskjuggler/apps/Tj3Man.rb
+++ b/lib/taskjuggler/apps/Tj3Man.rb
@@ -36,10 +36,12 @@ class TaskJuggler
 
     def processArguments(argv)
       super do
-        @opts.banner += <<'EOT'
+        @opts.banner.prepend(<<'EOT'
 This program can be used to generate the user manual in HTML format or to get
 a textual help for individual keywords.
+
 EOT
+	)
         @opts.on('-d', '--dir <directory>', String,
                 format('directory to put the manual')) do |dir|
           @directory = dir

--- a/lib/taskjuggler/apps/Tj3Man.rb
+++ b/lib/taskjuggler/apps/Tj3Man.rb
@@ -48,7 +48,7 @@ EOT
         end
         @opts.on('--html',
                  format('Show the user manual in your local web browser. ' +
-                        'By default, Firefox is used or the brower specified ' +
+                        'By default, Firefox is used or the browser specified ' +
                         'with the $BROWSER environment variable.')) do
           @showHtml = true
         end

--- a/lib/taskjuggler/apps/Tj3SsReceiver.rb
+++ b/lib/taskjuggler/apps/Tj3SsReceiver.rb
@@ -27,13 +27,15 @@ class TaskJuggler
 
     def processArguments(argv)
       super do
-        @opts.banner += <<'EOT'
+        @opts.banner.prepend(<<'EOT'
 This program can be used to receive filled-out status sheets via email.
 It reads the emails from STDIN and extracts the status sheet from the
 attached files. The status sheet is checked for correctness. Good status
 sheets are filed away. The sender be informed by email that the status
 sheets was accepted or rejected.
+
 EOT
+	)
       end
     end
 

--- a/lib/taskjuggler/apps/Tj3SsSender.rb
+++ b/lib/taskjuggler/apps/Tj3SsSender.rb
@@ -38,11 +38,13 @@ class TaskJuggler
 
     def processArguments(argv)
       super do
-        @opts.banner += <<'EOT'
+        @opts.banner.prepend(<<'EOT'
 This program can be used to out status sheets templates via email. It will
 generate status sheet templates for managers of the project. The project data
 will be accesses via tj3client from a running TaskJuggler server process.
+
 EOT
+	)
         @opts.on('-r', '--resource <ID>', String,
                  format('Only generate template for given resource')) do |arg|
           @resourceList << arg

--- a/lib/taskjuggler/apps/Tj3TsReceiver.rb
+++ b/lib/taskjuggler/apps/Tj3TsReceiver.rb
@@ -30,13 +30,15 @@ class TaskJuggler
 
     def processArguments(argv)
       super do
-        @opts.banner += <<'EOT'
+        @opts.banner.prepend(<<'EOT'
 This program can be used to receive filled-out time sheets via email.  It
 reads the emails from STDIN and extracts the time sheet from the attached
 files. The time sheet is checked for correctness. Good time sheets are filed
 away. The sender will be informed by email that the time sheets was accepted
 or rejected.
+
 EOT
+	)
       end
     end
 

--- a/lib/taskjuggler/apps/Tj3TsSender.rb
+++ b/lib/taskjuggler/apps/Tj3TsSender.rb
@@ -37,11 +37,13 @@ class TaskJuggler
 
     def processArguments(argv)
       super do
-        @opts.banner += <<'EOT'
+        @opts.banner.prepend(<<'EOT'
 This program can be used to send out time sheets templates via email. It will
 generate time sheet templates for all resources of the project. The project
 data will be accesses via tj3client from a running TaskJuggler server process.
+
 EOT
+	)
         @opts.on('-r', '--resource <ID>', String,
                 format('Only generate template for given resource')) do |arg|
           @resourceList << arg

--- a/lib/taskjuggler/apps/Tj3TsSummary.rb
+++ b/lib/taskjuggler/apps/Tj3TsSummary.rb
@@ -36,12 +36,14 @@ class TaskJuggler
 
     def processArguments(argv)
       super do
-        @opts.banner += <<'EOT'
+        @opts.banner.prepend(<<'EOT'
 This program can be used to send out individual copies and a summary of all
 accepted time sheets a list of email addresses. The directory structures for
 templates and submitted time sheets must be present. The project data will be
 accesses via tj3client from a running TaskJuggler server process.
+
 EOT
+	)
         @opts.on('-r', '--resource <ID>', String,
                  format('Only generate summary for given resource')) do |arg|
           @resourceList << arg

--- a/lib/taskjuggler/apps/Tj3WebD.rb
+++ b/lib/taskjuggler/apps/Tj3WebD.rb
@@ -40,11 +40,13 @@ class TaskJuggler
 
     def processArguments(argv)
       super do
-        @opts.banner += <<'EOT'
+        @opts.banner.prepend(<<'EOT'
 The TaskJuggler web server can be used to serve the HTTP reports of
 TaskJuggler projects to be viewed by any HTML5 compliant web browser. It uses
 the TaskJuggler daemon (tj3d) for data hosting and report generation.
+
 EOT
+	)
         @opts.on('-d', '--dont-daemonize',
                  format("Don't put program into daemon mode. Keep it " +
                         'connected to the terminal and show debug output.')) do

--- a/taskjuggler.gemspec
+++ b/taskjuggler.gemspec
@@ -53,7 +53,7 @@ EOT
             (`git ls-files -- tasks`).split("\n") +
             %w( .gemtest taskjuggler.gemspec Rakefile ) +
             # Generated files, not contained in Git repository.
-            %w( data/tjp.vim ) + Dir.glob('manual/html/**/*')
+            %w( data/tjp.vim ) + Dir.glob('manual/html/**/*') + Dir.glob('man/*.1')
   s.bindir = 'bin'
   s.executables = (`git ls-files -- bin`).split("\n").
                   map { |fn| File.basename(fn) }

--- a/tasks/gem.rake
+++ b/tasks/gem.rake
@@ -11,6 +11,7 @@ task :gem => [:clobber] do
   Rake::Task[:manual].invoke
   Rake::Task[:changelog].invoke
   Rake::Task[:permissions].invoke
+  Rake::Task[:help2man].invoke
 
   load 'taskjuggler.gemspec';
 

--- a/tasks/help2man.rake
+++ b/tasks/help2man.rake
@@ -1,0 +1,16 @@
+# TASK MAN GENERATE
+
+CLOBBER.include "man"
+
+directory "man"
+
+desc 'Generate man pages from help'
+task :help2man => 'man' do
+	help2man = %x{which help2man}
+	help2man.chomp!
+	Dir.foreach('bin') do |prog|
+		next if prog == '.' or prog == '..'
+		system help2man,"--output=man/#{prog}.1","--no-info","--manual=TaskJuggler",*("--include=h2m/#{prog}.h2m" unless !File.exists?("h2m/#{prog}.h2m")),"bin/#{prog}"
+	end
+end
+


### PR DESCRIPTION
The commits in this pull request:

1) Add a rake task to generate man pages for each TaskJuggler program, based on the program's --help and --version options. The man pages are generated using GNU help2man [0].

2) Add include files (h2m/*.h2m) to augment the information provided by --help and --version.

3) A number of modifications to the format of the --help and --version output are required in order for help2man to produce a readable man page. These have been kept to a minimum.

4) The man pages are included in the gem, in the directory ./man in order that they can be read with gem-man[1].

5) A spelling mistake in tj3man's --help output is corrected.

The motivation for this work is that some distributions (e.g. Debian) consider a program without a man page to be a bug[2]. (Taskjuggler is now packaged for Debian unstable in the package tj3 [3]).

Thanks.

Christopher Hoskin

[0] https://www.gnu.org/software/help2man/
[1] https://rubygems.org/gems/gem-man/
[2] https://www.debian.org/doc/debian-policy/ch-docs.html
[3] https://packages.debian.org/sid/tj3
