### PR TITLE
hasalert sometimes ignores the report time frame

### DIFF
--- a/lib/taskjuggler/Journal.rb
+++ b/lib/taskjuggler/Journal.rb
@@ -613,7 +613,7 @@ class TaskJuggler
     # This function returns a list of entries that have all the exact same
     # date and are the last entries before the deadline _date_. Only messages
     # with at least the required alert level _minLevel_ are returned. Messages
-    # with alert level _minLevel_ must be newer than _minDate_.
+    # with alert level _minLevel_ or higher must be newer than _minDate_.
     def currentEntries(date, property, minLevel, minDate, logExp)
       pEntries = getEntries(property) ?  getEntries(property).last(date) :
                  JournalEntryList.new
@@ -621,7 +621,7 @@ class TaskJuggler
       # date.
       pEntries.delete_if do |e|
         e.headline.empty? || e.alertLevel < minLevel ||
-        (e.alertLevel == minLevel && minDate && e.date < minDate)
+        (e.alertLevel >= minLevel && minDate && e.date < minDate)
       end
 
       unless pEntries.empty?


### PR DESCRIPTION
hasalert documentation states:
>     Will evaluate to true if the current property has a current alert message
>     within the report time frame and with at least the provided alert level.
    
But actually it evaluate to true if the current property has a current alert message within the report time frame and with the provided alert level or it has a higher-level alert message within any period of time.