### PR TITLE
add novevents keyword to icalreport context

### DIFF
--- a/lib/taskjuggler/Project.rb
+++ b/lib/taskjuggler/Project.rb
@@ -462,7 +462,9 @@ class TaskJuggler
         [ 'weekStartsMonday', 'Week Starts Monday', BooleanAttribute,
               true,  true,    false, false ],
         [ 'width',     'Width',        IntegerAttribute,
-              true,  false,   false, 640 ]
+              true,  false,   false, 640 ],
+        [ 'novevents',  'No vevents in icalreports', BooleanAttribute,
+              true,  false,   false, false ]
       ]
       attrs.each { |a| @reports.addAttributeType(AttributeDefinition.new(*a)) }
 

--- a/lib/taskjuggler/TjpSyntaxRules.rb
+++ b/lib/taskjuggler/TjpSyntaxRules.rb
@@ -1825,6 +1825,11 @@ EOT
     pattern(%w( !reportStart ))
     pattern(%w( !rollupresource ))
     pattern(%w( !rolluptask ))
+    pattern(%w( _novevents), lambda { @property.set('novevents', [ true ]) })
+    doc('novevents', <<'EOT'
+Don't add VEVENT entries to generated [[icalreport]]s.
+EOT
+    )
 
     pattern(%w( _scenario !scenarioId ), lambda {
       # Don't include disabled scenarios in the report
@@ -1863,6 +1868,8 @@ EOT
         # Show all journal entries.
         @property.set('hideJournalEntry',
                       LogicalExpression.new(LogicalOperation.new(0)))
+        # Add VEVENT entries to icalreports by default
+        @property.set('novevents', [ false ])
       end
     })
     arg(1, 'file name', <<'EOT'

--- a/lib/taskjuggler/reports/ICalReport.rb
+++ b/lib/taskjuggler/reports/ICalReport.rb
@@ -96,7 +96,7 @@ class TaskJuggler
 
         # Generate an additional VEVENT entry for all leaf tasks that aren't
         # milestones.
-        if task.leaf? && !task['milestone', scenarioIdx]
+        if task.leaf? && !task['milestone', scenarioIdx] && @report.get('novevents') == [false]
           event = ICalendar::Event.new(
             @ical, "#{task['projectid', scenarioIdx]}-#{task.fullId}",
             task.name, task['start', scenarioIdx], task['end', scenarioIdx])


### PR DESCRIPTION
I was, for a long time, disturbed by the fact, that icalreports contained both VEVENT and VTODO entries for tasks. This PR adds the keyword `novevents` to the icalreport context. When this keyword is specified within a icalreport definition, VEVENT entries will no longer be created, just VTODO ones.