### PR TITLE
Jkrenzer patch 1

### DIFF
--- a/lib/taskjuggler/Query.rb
+++ b/lib/taskjuggler/Query.rb
@@ -154,7 +154,7 @@ class TaskJuggler
         end
 
         # Same for the scope property.
-        if !@scopeProperty.nil? && !@scopePropertyId.nil?
+        if @scopeProperty.nil? && !@scopePropertyId.nil?
           @scopeProperty = resolvePropertyId(@scopePropertyType,
                                              @scopePropertyId)
           unless @scopeProperty

--- a/lib/taskjuggler/TaskScenario.rb
+++ b/lib/taskjuggler/TaskScenario.rb
@@ -1508,6 +1508,7 @@ class TaskJuggler
             end
             q = query.dup
             q.property = resource
+            q.scopeProperty = @property
             rti.setQuery(q)
             list << "<nowiki>#{rti.to_s}</nowiki>"
           else


### PR DESCRIPTION
Hi!

Currently in the task-report for the column resources the scope-property is not set, so we cannot get the per-task effort of the assigned resources.

This patch introduces setting the scope-property accordingly, so f.e. the effort of a assigned resource will be shown for the assigned task only and not the total effort. Total effort is still accessbile by using the query-generator with an empty scope-property.

According to the in-code documentation, this seems like the way it was originally intended to work. Hope this patch helps.

As my experience with the internal workings of TJ stems from reading up, I recommend checking for repercussion on other parts of the code. But at least in my instance everything seems to work as expected.

Kind regards,

Jörn