### PR TITLE
fix: Fix a bug where time sheet checks would fail

### DIFF
--- a/lib/taskjuggler/ResourceScenario.rb
+++ b/lib/taskjuggler/ResourceScenario.rb
@@ -913,6 +913,14 @@ class TaskJuggler
       slots
     end
 
+    def countOnShiftSlots(startIdx, endIdx)
+      slots = 0
+      startIdx.upto(endIdx - 1) do |idx|
+        slots += 1 if onShift?(idx)
+      end
+      slots
+    end
+
     # Limit the _startIdx_ and _endIdx_ to the actually assigned interval.
     # If _task_ is provided, fit it for the bookings of this particular task.
     def fitIndicies(startIdx, endIdx, task = nil)

--- a/lib/taskjuggler/TimeSheets.rb
+++ b/lib/taskjuggler/TimeSheets.rb
@@ -337,8 +337,9 @@ class TaskJuggler
       project = @resource.project
       startIdx = project.dateToIdx(@interval.start)
       endIdx = project.dateToIdx(@interval.end)
-      @resource.getAllocatedSlots(@scenarioIdx, startIdx, endIdx, nil) +
-        @resource.getFreeSlots(@scenarioIdx, startIdx, endIdx)
+      shiftSlots = @resource.countOnShiftSlots(@scenarioIdx, startIdx, endIdx)
+      allocatedSlots = @resource.getAllocatedSlots(@scenarioIdx, startIdx, endIdx, nil)
+      [shiftSlots,allocatedSlots].max
     end
 
     # Converts allocation percentage into time slots.

--- a/lib/taskjuggler/TimeSheets.rb
+++ b/lib/taskjuggler/TimeSheets.rb
@@ -291,13 +291,13 @@ class TaskJuggler
         # reported work.
         delta = 1
         if totalSlots < (targetSlots - delta)
-          error('ts_work_too_low',
+          warning('ts_work_too_low',
                 "The total work to be reported for this time sheet " +
                 "is #{workWithUnit(targetSlots)} but only " +
                 "#{workWithUnit(totalSlots)} were reported.")
         end
         if totalSlots > (targetSlots + delta)
-          error('ts_work_too_high',
+          warning('ts_work_too_high',
                 "The total work to be reported for this time sheet " +
                 "is #{workWithUnit(targetSlots)} but " +
                 "#{workWithUnit(totalSlots)} were reported.")


### PR DESCRIPTION
This patch fixes an issue where time sheet check would report a too high
reporting requirement in time sheets when resource was booked outside of working
hours in the reporting interval.

If a resource has working hours from 8-12 mon-tue but was booked 8-16 Monday and
did not work Tuesday, the time sheet checker would report that the resource must
report 12 hours of work in the time sheet for that week. One would expect that 8
hours is enough, as the assigned working hours is 8 hours.

With this change, if the time sheet checker will accept that the resource worked
4 hours outside normal working hours on Monday, and will not require the
resource to work 4 additional hours in normal working hours on Tuesday.