### PR TITLE
_global.smtpServer setting not work

### DIFF
--- a/lib/taskjuggler/SheetHandlerBase.rb
+++ b/lib/taskjuggler/SheetHandlerBase.rb
@@ -166,11 +166,12 @@ class TaskJuggler
                   inReplyTo = nil)
       case @emailDeliveryMethod
       when 'smtp'
-        Mail.defaults do
-          delivery_method :smtp, {
+        settings_dto = {
             :address => @smtpServer,
-            :port => 25
-          }
+            :port => 25,
+        }
+        Mail.defaults do
+          delivery_method :smtp, settings_dto
         end
       when 'sendmail'
         Mail.defaults do


### PR DESCRIPTION
# send time sheet fail

> tj3d --debug
> tj3client add a.tjp

tj3ts_sender -f --debug

> output error message 

```
Exception `NoMethodError' at /home/simon/.rvm/gems/ruby-2.2.2/gems/mail-2.7.1/lib/mail/message.rb:2162 - undefined method `ascii_only?' for nil:NilClass
Email transmission failed: undefined method `ascii_only?' for nil:NilClass
```

# reason

address==nil when `Mail.defaults &block` runtime

hostname==nil in tlsconnect
    hostname.ascii_only? throw Exception('NoMethodError)

## backtrace

    /home/simon/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/openssl/ssl.rb:146:in `block (2 levels) in verify_certificate_identity'"
    /home/simon/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/openssl/ssl.rb:142:in `each'"
    /home/simon/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/openssl/ssl.rb:142:in `block in verify_certificate_identity'"
    /home/simon/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/openssl/ssl.rb:138:in `each'"
    /home/simon/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/openssl/ssl.rb:138:in `verify_certificate_identity'"
    /home/simon/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/openssl/ssl.rb:234:in `post_connection_check'"
    /home/simon/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/net/smtp.rb:589:in `tlsconnect'"
    /home/simon/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/net/smtp.rb:564:in `do_start'"
    /home/simon/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/net/smtp.rb:521:in `start'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/mail-2.7.1/lib/mail/network/delivery_methods/smtp.rb:112:in `start_smtp_session'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/mail-2.7.1/lib/mail/network/delivery_methods/smtp.rb:100:in `deliver!'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/mail-2.7.1/lib/mail/message.rb:2159:in `do_delivery'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/mail-2.7.1/lib/mail/message.rb:262:in `deliver'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/taskjuggler-3.7.1/lib/taskjuggler/SheetHandlerBase.rb:224:in `sendEmail'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/taskjuggler-3.7.1/lib/taskjuggler/SheetSender.rb:196:in `block in sendReportTemplates'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/taskjuggler-3.7.1/lib/taskjuggler/SheetSender.rb:181:in `each'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/taskjuggler-3.7.1/lib/taskjuggler/SheetSender.rb:181:in `sendReportTemplates'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/taskjuggler-3.7.1/lib/taskjuggler/SheetSender.rb:70:in `sendTemplates'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/taskjuggler-3.7.1/lib/taskjuggler/apps/Tj3TsSender.rb:71:in `appMain'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/taskjuggler-3.7.1/lib/taskjuggler/Tj3AppBase.rb:160:in `main'"
    /home/simon/.rvm/gems/ruby-2.2.2/gems/taskjuggler-3.7.1/lib/tj3ts_sender.rb:16:in `<top (required)>'"


# my env

> .taskjugglerrc

```
_global:
  emailDeliveryMethod: smtp
  smtpServer: smtp.localhost
  projectId: acso
```


gems/ruby-2.2.2/gems/taskjuggler-3.7.1
gems/ruby-2.2.2/gems/mail-2.7.1

ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-linux]

postfix: `local only`, and `smtpd_tls_security_level=may`

Ubuntu 20.04.2 LTS \n \l