### PR TITLE
Improve alert color contrast in examples

### DIFF
--- a/examples/ProjectTemplate/template.tjp
+++ b/examples/ProjectTemplate/template.tjp
@@ -242,9 +242,9 @@ taskreport overview "" {
 # Macro to set the background color of a cell according to the alert
 # level of the task.
 macro AlertColor [
-  cellcolor plan.alert = 0 "#00D000" # green
-  cellcolor plan.alert = 1 "#D0D000" # yellow
-  cellcolor plan.alert = 2 "#D00000" # red
+  cellcolor plan.alert = 0 "#90FF90" # green
+  cellcolor plan.alert = 1 "#FFFF90" # yellow
+  cellcolor plan.alert = 2 "#FF9090" # red
 ]
 
 taskreport status "" {

--- a/examples/Tutorial/tutorial.tjp
+++ b/examples/Tutorial/tutorial.tjp
@@ -405,9 +405,9 @@ taskreport overview "" {
 # Macro to set the background color of a cell according to the alert
 # level of the task.
 macro AlertColor [
-  cellcolor plan.alert = 0 "#00D000" # green
-  cellcolor plan.alert = 1 "#D0D000" # yellow
-  cellcolor plan.alert = 2 "#D00000" # red
+  cellcolor plan.alert = 0 "#90FF90" # green
+  cellcolor plan.alert = 1 "#FFFF90" # yellow
+  cellcolor plan.alert = 2 "#FF9090" # red
 ]
 
 taskreport status "" {

--- a/test/TestSuite/Syntax/Correct/template.tjp
+++ b/test/TestSuite/Syntax/Correct/template.tjp
@@ -242,9 +242,9 @@ taskreport overview "" {
 # Macro to set the background color of a cell according to the alert
 # level of the task.
 macro AlertColor [
-  cellcolor plan.alert = 0 "#00D000" # green
-  cellcolor plan.alert = 1 "#D0D000" # yellow
-  cellcolor plan.alert = 2 "#D00000" # red
+  cellcolor plan.alert = 0 "#90FF90" # green
+  cellcolor plan.alert = 1 "#FFFF90" # yellow
+  cellcolor plan.alert = 2 "#FF9090" # red
 ]
 
 taskreport status "" {

--- a/test/TestSuite/Syntax/Correct/tutorial.tjp
+++ b/test/TestSuite/Syntax/Correct/tutorial.tjp
@@ -564,9 +564,9 @@ taskreport overview "" {
 # Macro to set the background color of a cell according to the alert
 # level of the task.
 macro AlertColor [
-  cellcolor plan.alert = 0 "#00D000" # green
-  cellcolor plan.alert = 1 "#D0D000" # yellow
-  cellcolor plan.alert = 2 "#D00000" # red
+  cellcolor plan.alert = 0 "#90FF90" # green
+  cellcolor plan.alert = 1 "#FFFF90" # yellow
+  cellcolor plan.alert = 2 "#FF9090" # red
 ]
 
 taskreport status "" {


### PR DESCRIPTION
This improves contrast ratio of the red alert box from [3.68:1](https://webaim.org/resources/contrastchecker/?fcolor=000000&bcolor=D00000) to
[9.64:1](https://webaim.org/resources/contrastchecker/?fcolor=000000&bcolor=FF9090), passing the WCAG 2.1 Level AAA contrast requirements.

https://www.w3.org/TR/WCAG21/#contrast-enhanced


#### Original
<img width="820" alt="old" src="https://user-images.githubusercontent.com/14329097/135714374-630532a8-3e69-4306-a944-1958ebe82890.png">

#### New
<img width="820" alt="new" src="https://user-images.githubusercontent.com/14329097/135714380-0f0e958f-c20e-4cc5-879b-820e590f9ca8.png">
