### PR TITLE
Adjust vim regex for tjpnumber to highlight minutes

### DIFF
--- a/lib/taskjuggler/VimSyntax.rb
+++ b/lib/taskjuggler/VimSyntax.rb
@@ -187,7 +187,7 @@ syn match tjparg contained /\${.*}/
 syn match tjpcomment /#.*$/
 syn match tjpcomment "//.*$"
 syn match tjpinclude /include.*$/
-syn match tjpnumber /\s[-+]\?\d\+\(\.\d\+\)\?\([hdwmy]\|min\)\?/
+syn match tjpnumber /\s[-+]\?\d\+\(\.\d\+\)\?\(min\|[hdwmy]\)\?/
 syn match tjpdate /\s\d\{4}-\d\{1,2}-\d\{1,2}\(-\d\{1,2}:\d\{1,2}\(:\d\{1,2}\)\?\(-[-+]\?\d\{4}\)\?\)\?/
 syn match tjptime /\s\d\{1,2}:\d\d\(:\d\d\)\?/
 


### PR DESCRIPTION
Love the program so far! Found this minor nit in the regex handling, where it would aggressively highlight the `m` only. This fixes the problem so `m` and `min` are both properly highlighted