### PR TITLE
Fix: How_To_Contribute: Fix link to correct section

### DIFF
--- a/manual/How_To_Contribute
+++ b/manual/How_To_Contribute
@@ -25,8 +25,8 @@ so that we can track the authorship of each submission. There is
 use github. 
 
 Make sure you have followed the steps described in the
-[Installation.html#Installation_Steps_for_Developers Installation
-Steps for Developers] chapter.
+[Installation.html#Installing_TaskJuggler_from_the_Git_Repository Installing
+TaskJuggler from the Git Repository] chapter.
 
 If you have never used Git before, you need to configure it first. You
 need to set your name and email address. This information will be


### PR DESCRIPTION
In How_To_Contribute, there's a link to installation instructions for developers. But that section doesn't exist. I changed this to point to an existing section about installing from the Git repository.