### PR TITLE
Fix UTF-8 issue in tj3ts_receiver

### DIFF
--- a/lib/taskjuggler/UTF8String.rb
+++ b/lib/taskjuggler/UTF8String.rb
@@ -127,6 +127,7 @@ class String
     else
       begin
         # Ensure that the text has LF line ends and is UTF-8 encoded.
+        force_encoding("UTF-8")
         encode('UTF-8', :universal_newline => true)
       rescue
         # The encoding of the String is broken. Find the first broken line and


### PR DESCRIPTION
When decoding an attachment the line.encoding is set to "ASCII-8BIT", even when reading an UTF-8 attachment. So, force the encoding indication and then check its compliant.

The fix is simple. An example of what happens is given in the attached email file "[testrb.eml.txt](https://github.com/fnino/TaskJuggler/files/8170575/testrb.eml.txt)" and a script which copies the relevant part of code with the force_encoding (attached .rb files were renamed to .rb.txt)

Run like so to see the bug: ruby bugutf.rb # creates a traceback

and like this to see the fix: ruby bugutf_fixed.rb # runs ok, accented characters like in "détails" are supported.


And thanks for all the good work, ,tj3 is amazing !


[testrb.eml.txt](https://github.com/taskjuggler/TaskJuggler/files/8170630/testrb.eml.txt)
[bugutf.rb.txt](https://github.com/taskjuggler/TaskJuggler/files/8170632/bugutf.rb.txt)
[bugutf_fixed.rb.txt](https://github.com/taskjuggler/TaskJuggler/files/8170634/bugutf_fixed.rb.txt)
