### PR TITLE
Fix: Multithreading exception

### DIFF
--- a/lib/taskjuggler/BatchProcessor.rb
+++ b/lib/taskjuggler/BatchProcessor.rb
@@ -248,7 +248,7 @@ class TaskJuggler
             # Remove the job from the @runningJobs Hash.
             @runningJobs.delete(pid)
             # Save the return value.
-            job.retVal = retVal.exitstatus
+            job.retVal = retVal
             if retVal.signaled?
               cleanPipes(job)
               # Aborted jobs will probably not send an EOT. So we fastrack


### PR DESCRIPTION
When generating multiple reports with more than one process TaskJuggler has thrown the following exception:
```
Checking scenario Aktuell                                    [      Done      ]
Fatal: undefined method `signaled?' for 0:Integer            [\]
/home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/Project.rb:764:in `block in generateReports'
/home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/BatchProcessor.rb:154:in `block in wait'
/usr/share/ruby/2.6/monitor.rb:235:in `mon_synchronize'
/home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/BatchProcessor.rb:149:in `wait'
/home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/Project.rb:760:in `generateReports'
/home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/TaskJuggler.rb:158:in `generateReports'
/home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/apps/Tj3.rb:216:in `appMain'
/home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/Tj3AppBase.rb:160:in `main'
/home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/tj3.rb:16:in `<top (required)>'
/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
/home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/bin/tj3:4:in `<top (required)>'
/home/root/bin/tj3:23:in `load'
/home/root/bin/tj3:23:in `<main>'
 
*******************************************************************************
You have triggered a bug in TaskJuggler version 3.7.2!
Please see the user manual on how to get this bug fixed!
http://www.taskjuggler.org/tj3/manual/Reporting_Bugs.html#Reporting_Bugs_and_Feature_Requests
*******************************************************************************
 
Traceback (most recent call last):
        13: from /home/root/bin/tj3:23:in `<main>'
        12: from /home/root/bin/tj3:23:in `load'
        11: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/bin/tj3:4:in `<top (required)>'
        10: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
         9: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
         8: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/tj3.rb:16:in `<top (required)>'
         7: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/Tj3AppBase.rb:160:in `main'
         6: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/apps/Tj3.rb:216:in `appMain'
         5: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/TaskJuggler.rb:158:in `generateReports'
         4: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/Project.rb:760:in `generateReports'
         3: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/BatchProcessor.rb:149:in `wait'
         2: from /usr/share/ruby/2.6/monitor.rb:235:in `mon_synchronize'
         1: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/BatchProcessor.rb:154:in `block in wait'
/home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/Project.rb:764:in `block in generateReports': undefined method `signaled?' for 0:Integer (NoMethodError)
        10: from /home/root/bin/tj3:23:in `<main>'
         9: from /home/root/bin/tj3:23:in `load'
         8: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/bin/tj3:4:in `<top (required)>'
         7: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
         6: from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:54:in `require'
         5: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/tj3.rb:16:in `<top (required)>'
         4: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/Tj3AppBase.rb:141:in `main'
         3: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/Tj3AppBase.rb:175:in `rescue in main'
         2: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/MessageHandler.rb:311:in `fatal'
         1: from /home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/MessageHandler.rb:190:in `fatal'
/home/root/.gem/ruby/2.6.0/gems/taskjuggler-3.7.2/lib/taskjuggler/MessageHandler.rb:300:in `addMessage': RuntimeError (RuntimeError)
```

This happens not only with ruby 2.6.0 and also with the newer versions like 3.2.0.

The fix is very simple.
In line 764 of Project.rb the signaled? method of class Process::Status is required and not only the exitstatus of the process.

The solution was tested by me in multiple taskjuggler projects.

Please include this into your main line.

Thank you for all your work on tj3!