### PR TITLE
Fix: FrozenError in project list

### DIFF
--- a/lib/taskjuggler/daemon/ReportServlet.rb
+++ b/lib/taskjuggler/daemon/ReportServlet.rb
@@ -172,7 +172,7 @@ class TaskJuggler
               "Cannot get project list from daemon: #{$!}")
       end
 
-      text = "== Welcome to the TaskJuggler Project Server ==\n----\n"
+      text = +"== Welcome to the TaskJuggler Project Server ==\n----\n"
       projects.each do |id|
         if id == projectId
           # Show the list of reports for this project.


### PR DESCRIPTION
To reproduce the issue, launch the web server with no configuration, add a project (its contents don't matter), and open http://127.0.0.1:8080/taskjuggler .

<details>
<summary><code>tj3webd</code> output</summary>

```
$ tj3webd -d --debug
TaskJuggler v3.8.4 - A Project Management Software

Copyright (c) 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020
              by Chris Schlaeger <cs@taskjuggler.org>

This program is free software; you can redistribute it and/or modify it under
the terms of version 2 of the GNU General Public License as published by the
Free Software Foundation.

[2025-11-27 20:30:10] INFO  WEBrick 1.9.2
[2025-11-27 20:30:10] INFO  ruby 3.4.1 (2024-12-25) [aarch64-linux-android]
[2025-11-27 20:30:10] INFO  WEBrick::HTTPServer#start: pid=7462 port=8080
127.0.0.1 - - [27/Nov/2025:20:30:36 CET] "GET /taskjuggler HTTP/1.1" 200 422
- -> /taskjuggler
Exception 'WEBrick::HTTPStatus::EOFError' at /data/data/com.termux/files/usr/lib/ruby/gems/3.4.0/gems/webrick-1.9.2/lib/webrick/httpserver.rb:82 - WEBrick::HTTPStatus::EOFError
Exception 'FrozenError' at /data/data/com.termux/files/usr/lib/ruby/gems/3.4.0/gems/taskjuggler-3.8.4/lib/taskjuggler/daemon/ReportServlet.rb:191 - can't modify frozen String: "== Welcome to the TaskJuggler Project Server ==\n----\n"
Error: Cannot serve GET request: GET /taskjuggler HTTP/1.1
Host: 127.0.0.1:8080
User-Agent: Mozilla/5.0 (Android 10; Mobile; rv:133.0) Gecko/133.0 Firefox/133.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
Accept-Language: en-US
Accept-Encoding: gzip, deflate, br, zstd
DNT: 1
Sec-GPC: 1
Connection: keep-alive
Upgrade-Insecure-Requests: 1
Sec-Fetch-Dest: document
Sec-Fetch-Mode: navigate
Sec-Fetch-Site: cross-site
Priority: u=0, i

can't modify frozen String: "== Welcome to the TaskJuggler Project Server ==\n----\n"
127.0.0.1 - - [27/Nov/2025:20:40:36 CET] "GET /taskjuggler HTTP/1.1" 412 563
- -> /taskjuggler
[2025-11-27 20:40:36] ERROR SystemExit: exit
        /data/data/com.termux/files/usr/lib/ruby/gems/3.4.0/gems/taskjuggler-3.8.4/lib/taskjuggler/MessageHandler.rb:298:in 'Kernel#exit'
        /data/data/com.termux/files/usr/lib/ruby/gems/3.4.0/gems/taskjuggler-3.8.4/lib/taskjuggler/MessageHandler.rb:298:in 'TaskJuggler::MessageHandlerInstance#addMessage'
        /data/data/com.termux/files/usr/lib/ruby/gems/3.4.0/gems/taskjuggler-3.8.4/lib/taskjuggler/MessageHandler.rb:197:in 'TaskJuggler::MessageHandlerInstance#error'
        /data/data/com.termux/files/usr/lib/ruby/gems/3.4.0/gems/taskjuggler-3.8.4/lib/taskjuggler/daemon/ReportServlet.rb:240:in 'TaskJuggler::ReportServlet#error'
        /data/data/com.termux/files/usr/lib/ruby/gems/3.4.0/gems/taskjuggler-3.8.4/lib/taskjuggler/daemon/ReportServlet.rb:62:in 'TaskJuggler::ReportServlet#do_GET'
        /data/data/com.termux/files/usr/lib/ruby/gems/3.4.0/gems/webrick-1.9.2/lib/webrick/httpservlet/abstract.rb:105:in 'WEBrick::HTTPServlet::AbstractServlet#service'
        /data/data/com.termux/files/usr/lib/ruby/gems/3.4.0/gems/webrick-1.9.2/lib/webrick/httpserver.rb:140:in 'WEBrick::HTTPServer#service'
        /data/data/com.termux/files/usr/lib/ruby/gems/3.4.0/gems/webrick-1.9.2/lib/webrick/httpserver.rb:96:in 'WEBrick::HTTPServer#run'
        /data/data/com.termux/files/usr/lib/ruby/gems/3.4.0/gems/webrick-1.9.2/lib/webrick/server.rb:309:in 'block in WEBrick::GenericServer#start_thread'
```

</details>