### PR TITLE
Bug Fix: Check to avoid partial bookings of multiple persistent mandatory resources with alternatives

### DIFF
--- a/lib/taskjuggler/TaskScenario.rb
+++ b/lib/taskjuggler/TaskScenario.rb
@@ -1840,7 +1840,9 @@ class TaskJuggler
 
       # We first have to make sure that if there are mandatory resources
       # that these are all available for the time slot.
+      # Note: These log entries can make the report file very long
       takenMandatories = []
+      #Log.msg { "BookResources:Mandatory Check: Start..." }
       @mandatories.each do |allocation|
         return unless allocation.onShift?(@currentSlotIdx)
 
@@ -1848,6 +1850,7 @@ class TaskJuggler
         # alternatives must be available.
         found = false
         allocation.candidates(@scenarioIdx).each do |candidate|
+          #Log.msg { "BookResources:Mandatory Check: Checking #{candidate.name}" }
           # When a resource group is marked mandatory, all members of the
           # group must be available.
           allAvailable = true
@@ -1870,7 +1873,23 @@ class TaskJuggler
         end
 
         # At least one mandatory resource is not available. We cannot continue.
+        Log.msg { "BookResources:Mandatory Check: At least one mandatory resource is not available. T #{@property.fullId}" } unless found
         return unless found
+        #Log.msg { "BookResources:Mandatory Check: All mandatories available. Task #{@property.fullId}" }
+      end
+
+      # Check if any persistent resources are mandatory, and don't make a
+      # booking if any of them are unavaliable 
+      @allocate.each do |allocation|
+        next unless allocation.lockedResource && allocation.mandatory
+        # Make the same check book() does to see if a booking would be succesful,
+        # and if not return.
+        allocation.lockedResource.allLeaves.each do |resource|
+          next if resource.available?(@scenarioIdx, @currentSlotIdx) &&
+               limitsOk?(@currentSlotIdx, resource) && allocation.onShift?(@currentSlotIdx)
+          Log.msg { "BookResources:Persistent Mandatory Check: Task #{@property.fullId} Bookings for slot #{@currentSlotIdx} aborted. #{allocation.lockedResource.name}, is persistent and mandatory but not avaliable." }
+          return
+        end
       end
 
       @allocate.each do |allocation|
@@ -1884,6 +1903,7 @@ class TaskJuggler
 
           if allocation.atomic &&
              locked_candidate.bookedTask(@scenarioIdx, @currentSlotIdx)
+            Log.msg { "Rolling back #{@property.fullId}."}
             rollbackBookings
             return
           end


### PR DESCRIPTION
I found a bug while trying to make a schedule with a pool of material resources like rooms (resources with an efficiency = 0.0) and a pool of normal resources like teachers, which relies heavily on the constraints 'persistent' and 'mandatory'

A teacher should be scheduled to teach an entire class in a room. 

I found that the section of TaskScenario that checks whether all mandatory resources are available sometimes passes when one of the current persistent resources is not available. It seems to occur when the current persitent resource is not included in the list of alternatives that is given to the mandatory check.

The result is bookResource() fails on one or more persistent mandatory resources, but books the rest of the persistent resources that are available. This can result in a teacher scheduled for a class bit with no room.

In the supplied example it can be seen that Class 3 and Class 2 are both scheduled to be conducted in room 1.
<img width="823" height="534" alt="IncorrectBehaviour" src="https://github.com/user-attachments/assets/8dfceab6-36cb-4ec7-9545-7714a0a19244" />

After making my commit, this conflict no longer occurs
<img width="856" height="530" alt="CorrectBehaviour" src="https://github.com/user-attachments/assets/629592e5-c779-4870-8110-1d4e587a3328" />

```
/* 1. Project Header: ID, Name, Version, and Timeframe */
project prj "My First Project" "1.0" 2026-03-30 - 2027-03-30 {
  timeformat "%Y-%m-%d"
  shorttimeformat "%H:%M"
  now 2026-03-30
}

/* 2. Resources: Who is doing the work? */
/* 2.1 People */
resource t1 "Teacher1"
resource t2 "Teacher2"
resource t3 "Teacher3"

macro allocate_Teacher [
  allocate t1 {alternative t2
               select minallocated
               persistent
               mandatory
               }
]

/* 2.2 Rooms */
resource r1 "Room1" { efficiency 0.0 }
resource r2 "Room2" { efficiency 0.0 }
resource r3 "Room3" { efficiency 0.0 }

/* 3. Tasks: What needs to be done? */
task c001 "Class1" { effort 4h  ${allocate_Teacher} allocate r1 { alternative r2, r3 select minallocated persistent mandatory } }
task c002 "Class2" { effort 8h  ${allocate_Teacher} allocate r1 { alternative r2, r3 select minallocated persistent mandatory } priority 600 start 2026-03-31}
task c003 "Class3" { effort 16h ${allocate_Teacher} allocate r1 { alternative r2, r3 select minallocated persistent mandatory } priority 550 }
task c004 "Class4" { effort 24h ${allocate_Teacher} allocate r1 { alternative r2, r3 select minallocated persistent mandatory } }
task c005 "Class5" { effort 26h ${allocate_Teacher} allocate r1 { alternative r2, r3 select minallocated persistent mandatory } }

/* 4. Reports: Define what you want to see */
resourcereport "ResourceGanttCorrected" {
  formats html
  headline "Resource Allocation ChartCorrected"
  loadunit hours
  columns no, name, start, end, resources, effort, duration, chart { scale hour width 1000}
  hidetask ~isleaf()
}

taskreport "PlanCorrected" {
  formats html
  headline "My Project Gantt ChartCorrected"
  loadunit hours
  # The 'chart' column generates the visual Gantt bars
  columns bsi { title 'WBS' }, name, start, end, duration, effort, resources, chart { scale hour width 1000 }
}

taskreport "GanttChartCorrected" {
  formats html
  headline "Project Gantt ChartCorrected"
  columns no, name, start, end, effort, duration, chart { scale hour width 1000 }
  timeformat "%a %Y-%m-%d"
  loadunit hours
  hideresource 0
}
```