### PR TITLE
Fix `tj3d --webserver`

### DIFF
--- a/lib/taskjuggler/daemon/Daemon.rb
+++ b/lib/taskjuggler/daemon/Daemon.rb
@@ -69,7 +69,7 @@ class TaskJuggler
 
       # We no longer have a controlling terminal, so these are useless.
       $stdin.reopen('/dev/null')
-      $stdout.reopen(StringIO.new)
+      $stdout.reopen('/dev/null', 'a')
       $stderr.reopen($stdout)
 
       info('daemon_pid',

--- a/lib/taskjuggler/daemon/ReportServlet.rb
+++ b/lib/taskjuggler/daemon/ReportServlet.rb
@@ -105,9 +105,13 @@ class TaskJuggler
       # text from the report server. This buffer will contain the generated
       # report as HTML encoded text. They will be send via DRb, so we have to
       # extend them with DRbUndumped.
-      stdOut = StringIO.new('')
+      #
+      # Note: In Ruby 4.0+, StringIO.new('') unexpectedly creates a read-only
+      # buffer in the web server context. Using StringIO.new without arguments
+      # avoids this issue. Root cause not yet identified.
+      stdOut = StringIO.new
       stdOut.extend(DRbUndumped)
-      stdErr = StringIO.new('')
+      stdErr = StringIO.new
       stdErr.extend(DRbUndumped)
 
       begin
@@ -119,6 +123,7 @@ class TaskJuggler
         end
 
         error('rs_io_connect_failed', "Can't connect IO: #{$!}")
+        return
       end
 
       # Ask the ReportServer to generate the reports with the provided ID.


### PR DESCRIPTION
With the latest commit, I was running into an issue where using `tj3d --webserver` to run the webserver would run, but when one would try to view the page in a browser, I'd get a crash with errors like `ERROR: Report server crashed: connection closed`. 

I used opencode/qwen3.6 to investigate the issue, and it did manage to fix it with these minimal changes. Why this now works is unclear though---i did look, but can't find a clear reason, especially given that in isolated tests, the stringio.new change makes no difference, so this is somehow specific to taskjuggler's setup.